### PR TITLE
Use different emoji characters in mojang command

### DIFF
--- a/plugins/mojang.py
+++ b/plugins/mojang.py
@@ -3,9 +3,9 @@ from cloudbot.util import http
 import json
 
 yes_prefix=u"\x02\x0f"
-yes_suffix=u": \x033\x02\u2714"
+yes_suffix=u": \x033\x02\u2611\ufe0f"
 no_prefix=u"\x02\x0f"
-no_suffix=u": \x034\x02\u2716"
+no_suffix=u": \x034\x02\U0001F6AB"
 
 @hook.command()
 def mojang():


### PR DESCRIPTION
Switches away from the old multiplication symbols that many fonts render
as dark grey, causing issues on dark backgrounds.

Now uses BALLOT BOX WITH CHECK (U+2611) and NO ENTRY SIGN (U+1F6AB)

![screenshot](https://i.imgur.com/CGq450D.png)